### PR TITLE
CI: Push previews to gh-pages

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,10 +1,15 @@
-name: deploy-gh-pages
+name: Deploy PR previews
 
 on:
-  push: {branches: [main]}
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
 
 concurrency:
-  group: github-pages-${{ github.ref }}
+  group: preview-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -24,7 +29,7 @@ jobs:
       run: python -m bsmschema specification/schema/
     - name: Build
       run: jb build -W specification
-    - uses: peaceiris/actions-gh-pages@v3
+    - name: Deploy preview
+      uses: rossjrw/pr-preview-action@v1
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: specification/_build/html
+        source-dir: ./specification/_build/html


### PR DESCRIPTION
It would be nice to preview PRs. Trying out https://github.com/marketplace/actions/deploy-pr-preview.