### PR TITLE
Add .mailmap to join two disjoint Dylans

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Dylan Nielson <adenosine@gmail.com>


### PR DESCRIPTION
He used two names for the same email address, and  git shortlog -sn was listing him separately without aggregating commits