### PR TITLE
TMP: Default to light mode until we update things to look good in dark

### DIFF
--- a/specification/_config.yml
+++ b/specification/_config.yml
@@ -75,3 +75,6 @@ sphinx:
     suppress_warnings:
       - etoc.toctree
       - myst.domains
+    # Default to light mode until we update things to look good in dark
+    html_context:
+      default_mode: light


### PR DESCRIPTION
Until #79 is addressed, we should improve the readability by reverting to light theme. This still allows dark to be toggled.